### PR TITLE
feat(DQ-43): Implements get departments API

### DIFF
--- a/src/main/java/api/docq/config/config/SecurityConfig.java
+++ b/src/main/java/api/docq/config/config/SecurityConfig.java
@@ -13,6 +13,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -38,6 +43,7 @@ public class SecurityConfig {
 
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
@@ -53,5 +59,18 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*")); // 개발 시 모든 Origin 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/api/docq/domain/clinic/controller/ClinicController.java
+++ b/src/main/java/api/docq/domain/clinic/controller/ClinicController.java
@@ -2,9 +2,7 @@ package api.docq.domain.clinic.controller;
 
 import api.docq.common.dto.AuthUser;
 import api.docq.domain.clinic.dto.request.ClinicCreateRequest;
-import api.docq.domain.clinic.dto.response.ClinicCreateRespone;
-import api.docq.domain.clinic.dto.response.ClinicGetAllResponse;
-import api.docq.domain.clinic.dto.response.ClinicGetResponse;
+import api.docq.domain.clinic.dto.response.*;
 import api.docq.domain.clinic.service.ClinicService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,4 +52,13 @@ public class ClinicController {
     ) {
         return ResponseEntity.ok(clinicService.getClinic(pageable));
     }
+
+    /**
+     * 병원 진료과 조회
+     */
+    @GetMapping("/departments")
+    public ResponseEntity<ClinicGetDepartmentResponse> getClinicDepartments() {
+        return ResponseEntity.ok(clinicService.getClinicDepartments());
+    }
+
 }

--- a/src/main/java/api/docq/domain/clinic/dto/response/ClinicDepartmentResponse.java
+++ b/src/main/java/api/docq/domain/clinic/dto/response/ClinicDepartmentResponse.java
@@ -1,0 +1,23 @@
+package api.docq.domain.clinic.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ClinicDepartmentResponse {
+    private final String name;
+    private final String icon;
+    
+    @Builder
+    private ClinicDepartmentResponse(String name, String icon) {
+        this.name = name;
+        this.icon = icon;
+    }
+    
+    public static ClinicDepartmentResponse of(String name, String icon) {
+        return ClinicDepartmentResponse.builder()
+                .name(name)
+                .icon(icon)
+                .build();
+    }
+}

--- a/src/main/java/api/docq/domain/clinic/dto/response/ClinicDepartmentResponse.java
+++ b/src/main/java/api/docq/domain/clinic/dto/response/ClinicDepartmentResponse.java
@@ -6,18 +6,15 @@ import lombok.Getter;
 @Getter
 public class ClinicDepartmentResponse {
     private final String name;
-    private final String icon;
-    
+
     @Builder
-    private ClinicDepartmentResponse(String name, String icon) {
+    private ClinicDepartmentResponse(String name) {
         this.name = name;
-        this.icon = icon;
     }
     
-    public static ClinicDepartmentResponse of(String name, String icon) {
+    public static ClinicDepartmentResponse of(String name) {
         return ClinicDepartmentResponse.builder()
                 .name(name)
-                .icon(icon)
                 .build();
     }
 }

--- a/src/main/java/api/docq/domain/clinic/dto/response/ClinicGetDepartmentResponse.java
+++ b/src/main/java/api/docq/domain/clinic/dto/response/ClinicGetDepartmentResponse.java
@@ -1,0 +1,22 @@
+package api.docq.domain.clinic.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ClinicGetDepartmentResponse {
+    private List<ClinicDepartmentResponse> departments;
+
+    @Builder
+    private ClinicGetDepartmentResponse(List<ClinicDepartmentResponse> departments) {
+        this.departments = departments;
+    }
+
+    public static ClinicGetDepartmentResponse of (List<ClinicDepartmentResponse> departments) {
+        return ClinicGetDepartmentResponse.builder()
+                .departments(departments)
+                .build();
+    }
+}

--- a/src/main/java/api/docq/domain/clinic/enums/Department.java
+++ b/src/main/java/api/docq/domain/clinic/enums/Department.java
@@ -9,12 +9,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Department {
-    DENTAL("치과"),
-    EYE_CLINIC("안과"),
-    ENT("이비인후과"),
-    DERMATOLOGY("피부과");
+    DENTAL("치과", "https://img.icons8.com/?size=100&id=m0Jn3S6j3Tev&format=png&color=000000"),
+    EYE_CLINIC("안과", "https://img.icons8.com/?size=100&id=SfoGooXDPPeC&format=png&color=000000"),
+    ENT("이비인후과", "https://img.icons8.com/?size=100&id=23292&format=png&color=000000"),
+    DERMATOLOGY("피부과", "https://img.icons8.com/?size=100&id=79381&format=png&color=000000");
 
     private final String departmentName;
+    private final String departmentIcon;
 
     public static Department fromName(String name) {
         for (Department department : Department.values()) {

--- a/src/main/java/api/docq/domain/clinic/enums/Department.java
+++ b/src/main/java/api/docq/domain/clinic/enums/Department.java
@@ -9,13 +9,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Department {
-    DENTAL("치과", "https://img.icons8.com/?size=100&id=m0Jn3S6j3Tev&format=png&color=000000"),
-    EYE_CLINIC("안과", "https://img.icons8.com/?size=100&id=SfoGooXDPPeC&format=png&color=000000"),
-    ENT("이비인후과", "https://img.icons8.com/?size=100&id=23292&format=png&color=000000"),
-    DERMATOLOGY("피부과", "https://img.icons8.com/?size=100&id=79381&format=png&color=000000");
+    DENTAL("치과"),
+    EYE_CLINIC("안과"),
+    ENT("이비인후과"),
+    DERMATOLOGY("피부과");
 
     private final String departmentName;
-    private final String departmentIcon;
 
     public static Department fromName(String name) {
         for (Department department : Department.values()) {

--- a/src/main/java/api/docq/domain/clinic/service/ClinicService.java
+++ b/src/main/java/api/docq/domain/clinic/service/ClinicService.java
@@ -112,7 +112,7 @@ public class ClinicService {
         Department[] departments = Department.values();
 
         List<ClinicDepartmentResponse> departMentList = Arrays.stream(departments).map(
-                department -> ClinicDepartmentResponse.of(department.getDepartmentName(), department.getDepartmentIcon())
+                department -> ClinicDepartmentResponse.of(department.getDepartmentName())
         ).toList();
 
         return ClinicGetDepartmentResponse.of(departMentList);

--- a/src/main/java/api/docq/domain/clinic/service/ClinicService.java
+++ b/src/main/java/api/docq/domain/clinic/service/ClinicService.java
@@ -1,10 +1,9 @@
 package api.docq.domain.clinic.service;
 
 import api.docq.domain.clinic.dto.request.ClinicCreateRequest;
-import api.docq.domain.clinic.dto.response.ClinicCreateRespone;
-import api.docq.domain.clinic.dto.response.ClinicGetAllResponse;
-import api.docq.domain.clinic.dto.response.ClinicGetResponse;
+import api.docq.domain.clinic.dto.response.*;
 import api.docq.domain.clinic.entity.Clinic;
+import api.docq.domain.clinic.enums.Department;
 import api.docq.domain.clinic.repository.ClinicRepository;
 import api.docq.domain.review.dto.response.ReviewResponse;
 import api.docq.domain.review.entity.Review;
@@ -19,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -105,6 +105,17 @@ public class ClinicService {
                         clinic.getCloseTime()
                         )
                 );
+    }
+
+    @Transactional(readOnly = true)
+    public ClinicGetDepartmentResponse getClinicDepartments() {
+        Department[] departments = Department.values();
+
+        List<ClinicDepartmentResponse> departMentList = Arrays.stream(departments).map(
+                department -> ClinicDepartmentResponse.of(department.getDepartmentName(), department.getDepartmentIcon())
+        ).toList();
+
+        return ClinicGetDepartmentResponse.of(departMentList);
     }
 
     public List<LocalTime> timeList(LocalTime openTime, LocalTime closeTime) {


### PR DESCRIPTION
## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] department에 대한 icon image 정보를 추가하였습니다. 
- [X] 진료과 리스트를 응답하는 api를 추가하였습니다. 


## 💡 PR 특이사항
프론트에서 진료과 데이터를 받아와 아이콘과 함께 화면에 표시할 수 있도록 백엔드에 관련 기능을 추가했습니다.


## 📸 스크린샷
API 호출 후 프론트 화면에 진료과 아이콘이 정상적으로 표시되었습니다. 
<img width="1803" height="522" alt="image" src="https://github.com/user-attachments/assets/80bb8e1e-4e2d-43d9-9700-ccee011d9301" />


